### PR TITLE
update parent image kali-linux with kali-rolling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,6 @@ RUN usermod -aG sudo newuser
 USER newuser
 WORKDIR /home/newuser
 
-# # install and setup linuxbrew
-# RUN $ sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
-# RUN test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
-# RUN test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-# RUN test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
-# RUN echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
-# RUN sudo mkdir -p /hilal/.linuxbrew/var/homebrew/linked
-# RUN sudo chown -R $(whoami) /hilal/.linuxbrew/var/homebrew/linked
-# RUN sudo mkdir -p /hilal/.linuxbrew/var/homebrew/locks
-# RUN sudo chown -R $(whoami) /hilal/.linuxbrew/var/homebrew/locks
-
 #Copy necessary files for VPN and tunneling
 COPY *.ovpn enable-tunnel.sh ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali-rolling
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM xterm-256color
 # do APT update

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Lazy Docker setup of Kali 🐲 Linux for HTB pen testing 🚩
 1. Download your OVPN file from HTB.eu and place it in this folder
 2. Build using: `docker build -t hilalh/kali-linux:latest .`
 3. Run using: `docker run -ti  --privileged hilalh/kali-linux:latest /bin/bash`
-4. Enable tunnel using `sudo ./enalbe-tunnel` inside the container (pass: newpassword)
+4. Enable tunnel using `sudo ./enable-tunnel` inside the container (pass: newpassword)
 5. Connect to vpn using `openvpn --config  <myvpnfile> --daemon`
 6. Start hacking ⚔️


### PR DESCRIPTION
The parent image ``kali-linux`` does not exist anymore on [docker hub](https://hub.docker.com/u/kalilinux). 